### PR TITLE
Extend resolve

### DIFF
--- a/lib/iron_core.js
+++ b/lib/iron_core.js
@@ -140,8 +140,8 @@ Iron.utils.namespace = function (namespace, value) {
  * var baz = Iron.foo.baz = {};
  * Iron.utils.resolve("Iron.foo.baz") === baz
  */
-Iron.utils.resolve = function (nameOrValue) {
-  var global = Iron.utils.global;
+Iron.utils.resolve = function (nameOrValue, obj, options) {
+  var global = obj || Iron.utils.global;
   var parts;
   var ptr;
 
@@ -155,6 +155,13 @@ Iron.utils.resolve = function (nameOrValue) {
     }
   } else {
     ptr = nameOrValue;
+  }
+
+  if (options && options.returnObject) {
+    ptr = {
+      keyExists: parts && parts.length === i ? true : false,
+      value: ptr
+    };
   }
 
   // final position of ptr should be the resolved value


### PR DESCRIPTION
Extends resolve function to accept an optional object to resolve from
and if object supplied an options object.

options.returnObject makes this function return an object

``` js
{
  keyExists: Boolean,
  value: ‘value usually return by this function’
}
```

This PR is related to
https://github.com/EventedMind/iron-router/pull/1084
