### PR TITLE
Adding package name for local Windows development

### DIFF
--- a/package.js
+++ b/package.js
@@ -1,6 +1,7 @@
 Package.describe({
   summary: 'Iron namespace and utilities.',
   version: '1.0.8',
+  name: 'iron:core'
 });
 
 Package.on_use(function (api) {


### PR DESCRIPTION
More background on this here: https://forums.meteor.com/t/local-packages-on-windows/6656

Essentially, I'd like to use iron router (great work!) but I need to store it locally, and also work on Windows.  The semi-colon is illegal in Windows file names, so I've added the name parameter to each of the iron packages that was missing it to allow local packages on Windows.

Thanks!