### PR TITLE
Rename a variable to avoid using JS strict mode reserved words.

### DIFF
--- a/lib/iron_core.js
+++ b/lib/iron_core.js
@@ -254,13 +254,13 @@ Function.prototype.deprecate = function (info) {
  * Returns a function that can be used to log debug messages for a given
  * package.
  */
-Iron.utils.debug = function (package) {
-  Iron.utils.assert(typeof package === 'string', "debug requires a package name");
+Iron.utils.debug = function (packageName) {
+  Iron.utils.assert(typeof packageName === 'string', "debug requires a package name");
 
   return function debug (/* args */) {
     if (console && console.log && Iron.debug === true) {
       var msg = _.toArray(arguments).join(' ');
-      console.log("%c<" + package + "> %c" + msg, "color: #999;", "color: #000;");
+      console.log("%c<" + packageName + "> %c" + msg, "color: #999;", "color: #000;");
     }
   };
 };


### PR DESCRIPTION
This makes it possible to use "uglify-es" for code minification (Meteor's default),
without having to fall back to Babel.minify().